### PR TITLE
feat(payments): implement mock payment flow and routing fixes

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -6,6 +6,10 @@ class ApiConstants {
   static const String supabaseUrl = 'https://txojopmkgjbqsfcacglz.supabase.co';
   static const String supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InR4b2pvcG1rZ2picXNmY2FjZ2x6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0MzMxODcsImV4cCI6MjA2NTAwOTE4N30.5itLemoP3J_05zZW9qS7yRb4RbBlZ2dy3J6GkDA1rkY';
   
+  // Payments / Integrations
+  // Toggle to true in development to bypass real Stripe calls
+  static const bool mockPayments = true;
+  
   // Storage Buckets
   static const String taskImagesBucket = 'task-images';
   

--- a/lib/features/applications/controllers/application_controller.dart
+++ b/lib/features/applications/controllers/application_controller.dart
@@ -121,59 +121,6 @@ class ApplicationController extends _$ApplicationController {
       return false;
     }
   }
-
-  Future<bool> acceptOffer({
-    required String applicationId,
-    required String taskId,
-    required String taskerId, // The user who made the offer
-  }) async {
-    dev.log('acceptOffer started for appId: $applicationId, taskId: $taskId');
-    state = const AsyncValue.loading();
-    final repo = ref.read(applicationRepositoryProvider);
-    try {
-      // Fetch the application to get the offer price
-      dev.log('Step 1: Getting application data...');
-      final acceptedApplication = await repo.getApplicationById(applicationId);
-      if (acceptedApplication == null) {
-        throw Exception('Application not found');
-      }
-      final offerPrice = acceptedApplication.offerPrice;
-      dev.log('Retrieved offer price: $offerPrice');
-
-      // Prepare all the data we'll need to update
-      dev.log('Step 2: Preparing data updates...');
-      final taskData = {
-        'status': 'pending', // Set status to 'pending' after an offer is accepted
-        'tasker_id': taskerId,
-        'price': offerPrice, // Use the 'price' field for the final agreed price
-      };
-      
-      // Execute each update in sequence
-      dev.log('Step 3: Updating application status...');
-      await repo.updateApplication(applicationId, {'status': 'accepted'});
-      
-      dev.log('Step 4: Updating task data...');
-      // Access TaskRepository directly rather than through ref to avoid any potential provider issues
-      final supabase = SupabaseService.client;
-      await supabase
-          .from('taskaway_tasks')
-          .update(taskData)
-          .eq('id', taskId);
-      dev.log('Task updated successfully');
-      
-      dev.log('Step 5: Rejecting other offers...');
-      await repo.rejectOtherOffers(taskId, applicationId);
-      dev.log('Other offers rejected successfully');
-      
-      dev.log('acceptOffer completed successfully');
-      state = const AsyncValue.data(null);
-      return true;
-    } catch (e, st) {
-      dev.log('acceptOffer failed with error: $e', error: e, stackTrace: st);
-      state = AsyncValue.error(e, st);
-      return false;
-    }
-  }
 }
 
 @riverpod

--- a/lib/features/messages/screens/message_screen.dart
+++ b/lib/features/messages/screens/message_screen.dart
@@ -492,18 +492,18 @@ class _MessageScreenState extends ConsumerState<MessageScreen> {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                 decoration: BoxDecoration(
-                  color: Colors.green.withValues(alpha: 0.1),
+                  color: Colors.orange.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
                   border: Border.all(
-                    color: Colors.green.withValues(alpha: 0.3),
+                    color: Colors.orange.withValues(alpha: 0.3),
                   ),
                 ),
                 child: const Text(
-                  'ASSIGNED',
+                  'PENDING',
                   style: TextStyle(
                     fontSize: 10,
                     fontWeight: FontWeight.bold,
-                    color: Colors.green,
+                    color: Colors.orange,
                   ),
                 ),
               ),

--- a/lib/features/notifications/screens/notifications_screen.dart
+++ b/lib/features/notifications/screens/notifications_screen.dart
@@ -149,7 +149,7 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
+            color: Colors.black.withValues(alpha: 0.05),
             blurRadius: 8,
             offset: const Offset(0, 2),
           ),

--- a/lib/features/payments/controllers/payment_controller.dart
+++ b/lib/features/payments/controllers/payment_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/stripe_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'dart:developer' as dev;
+import '../../../core/constants/api_constants.dart';
 
 final paymentControllerProvider = Provider((ref) => PaymentController());
 
@@ -12,8 +13,9 @@ class PaymentController {
 
   PaymentController();
 
-  /// Step 1-7: Complete payment flow when Poster approves task
-  Future<void> handleTaskApproval({
+  /// Step 1-3: Initialize payment flow when Poster approves task
+  /// Returns data needed for client-side authorization.
+  Future<Map<String, dynamic>> handleTaskApproval({
     required String taskId,
     required String posterId,
     required String taskerId,
@@ -24,13 +26,26 @@ class PaymentController {
       dev.log('=== Starting Stripe Payment Flow ===');
       dev.log('Task ID: $taskId');
       dev.log('Amount: \$${amount.toStringAsFixed(2)}');
+      
+      // Mock mode: skip Stripe + payment insert
+      if (ApiConstants.mockPayments) {
+        dev.log('[MOCK] Skipping Stripe PI and payment insert; updating task to pending_payment');
+        await _supabase.from('taskaway_tasks').update({
+          'status': 'pending_payment',
+          'updated_at': DateTime.now().toIso8601String(),
+        }).eq('id', taskId);
 
-      // Get poster profile for payment details
-      final posterData = await _supabase
-          .from('taskaway_profiles')
-          .select('full_name, email')
-          .eq('id', posterId)
-          .single();
+        final mockPaymentId = 'mock_' + taskId;
+        final mockClientSecret = 'cs_mock_' + taskId;
+        return {
+          'paymentId': mockPaymentId,
+          'clientSecret': mockClientSecret,
+          'amount': amount,
+          'taskTitle': taskTitle,
+        };
+      }
+      
+      // Use authenticated user's email for Stripe customer
 
       // Get current authenticated user
       final currentSession = _supabase.auth.currentSession;
@@ -46,7 +61,7 @@ class PaymentController {
       // === STEP 1: Create Stripe PaymentIntent (manual authorization) ===
       dev.log('Step 1: Creating Stripe PaymentIntent...');
       final paymentIntentData = await _stripeService.createPaymentIntent(
-        customerEmail: posterData['email'] ?? currentUser.email!,
+        customerEmail: currentUser.email!,
         amount: amount,
         description: 'Payment for task: $taskTitle',
         taskId: taskId,
@@ -59,10 +74,8 @@ class PaymentController {
         'payer_id': posterId,
         'payee_id': taskerId,
         'amount': amount,
-        'platform_fee_amount': paymentIntentData['platform_fee'],
         'status': 'pending_authorization',
         'stripe_payment_intent_id': paymentIntentData['payment_intent_id'],
-        'client_secret': paymentIntentData['client_secret'],
         'created_at': DateTime.now().toIso8601String(),
         'updated_at': DateTime.now().toIso8601String(),
       }).select().single();
@@ -79,10 +92,15 @@ class PaymentController {
       dev.log('✅ Payment flow initialized successfully');
       dev.log('Payment Intent ID: ${paymentIntentData['payment_intent_id']}');
       dev.log('Client Secret: ${paymentIntentData['client_secret']}');
-      
-      // Return the client secret for frontend payment confirmation
-      // The frontend will handle steps 4-7 after user confirms payment
-      
+
+      // Return init data for the authorization screen
+      return {
+        'paymentId': paymentData['id'],
+        'clientSecret': paymentIntentData['client_secret'],
+        'amount': amount,
+        'taskTitle': taskTitle,
+      };
+
     } catch (e, stackTrace) {
       dev.log('❌ Error in payment flow: $e');
       dev.log('Stack trace: $stackTrace');
@@ -98,6 +116,20 @@ class PaymentController {
     try {
       dev.log('=== Continuing Stripe Payment Flow ===');
       
+      // Mock mode: finalize without Stripe/DB payments read
+      if (ApiConstants.mockPayments) {
+        dev.log('[MOCK] Completing payment without Stripe/DB payments read');
+        final mockTaskId = paymentId.startsWith('mock_')
+            ? paymentId.substring(5)
+            : paymentId;
+        await _supabase.from('taskaway_tasks').update({
+          'status': 'completed',
+          'updated_at': DateTime.now().toIso8601String(),
+        }).eq('id', mockTaskId);
+        dev.log('[MOCK] Task set to completed for taskId=' + mockTaskId);
+        return;
+      }
+      
       // Get payment record
       final paymentData = await _supabase
           .from('taskaway_payments')
@@ -109,21 +141,64 @@ class PaymentController {
       final taskId = paymentData['task_id'];
       final taskerId = paymentData['payee_id'];
       final amount = paymentData['amount'];
-      final platformFee = paymentData['platform_fee_amount'] ?? 0.0;
-      final taskerAmount = amount - platformFee;
+      double platformFee =
+          (paymentData['platform_fee_amount'] as num?)?.toDouble() ?? 0.0;
+      if (platformFee == 0.0) {
+        // Fallback if column doesn't exist or wasn't stored
+        platformFee =
+            StripeService.calculatePlatformFee((amount as num).toDouble());
+      }
+      final taskerAmount = (amount as num).toDouble() - platformFee;
 
-      // === STEP 4: Authorize payment ===
-      dev.log('Step 4: Authorizing payment...');
-      await _stripeService.authorizePayment(
-        paymentIntentId: paymentIntentId,
-        paymentMethodId: paymentMethodId,
-      );
+      // === STEP 4: Ensure payment is authorized (confirmed) ===
+      dev.log('Step 4: Checking PaymentIntent status before authorization...');
+      final statusResp = await _stripeService.getPaymentIntentStatus(paymentIntentId);
+      String? stripeStatus;
+      if (statusResp['status'] is String) {
+        stripeStatus = statusResp['status'] as String?;
+      } else if (statusResp['payment_intent'] is Map &&
+          (statusResp['payment_intent'] as Map)['status'] is String) {
+        stripeStatus = (statusResp['payment_intent'] as Map)['status'] as String?;
+      }
 
-      // Update payment status
-      await _supabase.from('taskaway_payments').update({
-        'status': 'authorized',
-        'updated_at': DateTime.now().toIso8601String(),
-      }).eq('id', paymentId);
+      if (stripeStatus == null) {
+        throw Exception('Unable to determine PaymentIntent status');
+      }
+
+      dev.log('Stripe PaymentIntent status: $stripeStatus');
+
+      if (stripeStatus == 'requires_confirmation' ||
+          stripeStatus == 'requires_payment_method') {
+        dev.log('Confirming PaymentIntent on server...');
+        await _stripeService.authorizePayment(
+          paymentIntentId: paymentIntentId,
+          paymentMethodId: paymentMethodId,
+        );
+
+        await _supabase.from('taskaway_payments').update({
+          'status': 'authorized',
+          'updated_at': DateTime.now().toIso8601String(),
+        }).eq('id', paymentId);
+        // Refresh status after confirmation
+        final postConfirm = await _stripeService.getPaymentIntentStatus(paymentIntentId);
+        if (postConfirm['status'] is String) {
+          stripeStatus = postConfirm['status'] as String?;
+        } else if (postConfirm['payment_intent'] is Map &&
+            (postConfirm['payment_intent'] as Map)['status'] is String) {
+          stripeStatus = (postConfirm['payment_intent'] as Map)['status'] as String?;
+        }
+      } else if (stripeStatus == 'requires_action') {
+        // Client confirmation should have handled 3DS already
+        throw Exception('Additional authentication required. Please try again.');
+      }
+
+      // If PI is already confirmed and awaiting capture, mark payment as authorized
+      if (stripeStatus == 'requires_capture') {
+        await _supabase.from('taskaway_payments').update({
+          'status': 'authorized',
+          'updated_at': DateTime.now().toIso8601String(),
+        }).eq('id', paymentId);
+      }
 
       // === STEP 5: User approval is implicit at this point ===
       dev.log('Step 5: User has approved the payment authorization');
@@ -144,24 +219,27 @@ class PaymentController {
           .eq('id', taskerId)
           .single();
 
-      final taskerStripeAccountId = taskerProfile['stripe_account_id'];
+      String? taskerStripeAccountId = taskerProfile['stripe_account_id'] as String?;
+      if (taskerStripeAccountId == null && ApiConstants.mockPayments) {
+        dev.log('[MOCK] Using dummy tasker Stripe account id');
+        taskerStripeAccountId = 'acct_mock';
+      }
       if (taskerStripeAccountId == null) {
         throw Exception('Tasker has not connected their Stripe account');
       }
 
-      final transferData = await _stripeService.transferToTasker(
+      await _stripeService.transferToTasker(
         taskerStripeAccountId: taskerStripeAccountId,
         amount: taskerAmount,
         paymentIntentId: paymentIntentId,
       );
 
-      // === STEP 8: Update status to completed and record platform fee ===
+      // === STEP 8: Update status to completed ===
       dev.log('Step 8: Finalizing payment and updating statuses...');
       
       // Update payment record
       await _supabase.from('taskaway_payments').update({
         'status': 'completed',
-        'transfer_id': transferData['id'],
         'updated_at': DateTime.now().toIso8601String(),
       }).eq('id', paymentId);
 
@@ -179,11 +257,13 @@ class PaymentController {
       dev.log('❌ Error in payment authorization: $e');
       dev.log('Stack trace: $stackTrace');
       
-      // Update payment status to failed
-      await _supabase.from('taskaway_payments').update({
-        'status': 'failed',
-        'updated_at': DateTime.now().toIso8601String(),
-      }).eq('id', paymentId);
+      // Update payment status to failed (skip in mock)
+      if (!ApiConstants.mockPayments) {
+        await _supabase.from('taskaway_payments').update({
+          'status': 'failed',
+          'updated_at': DateTime.now().toIso8601String(),
+        }).eq('id', paymentId);
+      }
       
       throw Exception('Failed to process payment authorization: $e');
     }

--- a/lib/features/profile/screens/edit_profile_screen.dart
+++ b/lib/features/profile/screens/edit_profile_screen.dart
@@ -472,7 +472,7 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
           color: Colors.white,
           boxShadow: [
             BoxShadow(
-              color: Colors.grey.withOpacity(0.1),
+              color: Colors.grey.withValues(alpha: 0.1),
               spreadRadius: 1,
               blurRadius: 10,
               offset: const Offset(0, -2),

--- a/lib/features/profile/screens/payment_history_screen.dart
+++ b/lib/features/profile/screens/payment_history_screen.dart
@@ -249,9 +249,9 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen>
                 ),
               ),
               const SizedBox(height: 4),
-              Text(
+              const Text(
                 'Task payment', // Simplified for now
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w500,
                   color: Colors.black87,

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:go_router/go_router.dart';
 import '../../auth/controllers/auth_controller.dart';
 import 'edit_profile_screen.dart';
 import 'settings_screen.dart';

--- a/lib/features/tasks/models/task_status.dart
+++ b/lib/features/tasks/models/task_status.dart
@@ -1,23 +1,17 @@
-import 'package:freezed_annotation/freezed_annotation.dart';
+// ignore_for_file: constant_identifier_names
 
 /// Enum representing the status of a task.
 /// Matches the `taskaway_task_status` PostgreSQL enum.
 enum TaskStatus {
-  @JsonValue('pending')
   pending,
-  @JsonValue('open')
   open,
-  @JsonValue('assigned')
-  assigned,
-  @JsonValue('in_progress') // Assuming this might be a status
-  inProgress,
-  @JsonValue('completed')
+  in_progress,
+  pending_approval,
+  pending_payment,
   completed,
-  @JsonValue('cancelled')
-  cancelled,
-  @JsonValue('disputed') // Assuming this might be a status
-  disputed;
+  cancelled;
 
   String toJson() => name;
-  static TaskStatus fromJson(String json) => values.byName(json);
+  static TaskStatus fromJson(String json) =>
+      TaskStatus.values.firstWhere((e) => e.name == json);
 }

--- a/lib/features/tasks/repositories/task_repository.dart
+++ b/lib/features/tasks/repositories/task_repository.dart
@@ -39,6 +39,24 @@ class TaskRepository {
     }
   }
 
+  // Get tasks by IDs with optional status filter
+  Future<List<Task>> getTasksByIds(List<String> ids, {String? status}) async {
+    if (ids.isEmpty) return [];
+    try {
+      var query = supabase.from(_tableName).select();
+      final orExpr = ids.map((id) => 'id.eq.$id').join(',');
+      query = query.or(orExpr);
+      if (status != null) {
+        query = query.eq('status', status);
+      }
+      final response = await query.order('created_at', ascending: false);
+      return response.map((json) => Task.fromJson(json)).toList().cast<Task>();
+    } catch (e) {
+      dev.log('Error fetching tasks by ids: $e');
+      return [];
+    }
+  }
+
   // Creates a polling-based stream as a fallback when Realtime fails
   Stream<List<Task>> _createPollingStream() {
     // Use a periodic timer to poll data every 3 seconds

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -23,6 +23,8 @@ import '../features/tasks/screens/task_details_screen.dart';
 import '../features/tasks/screens/apply_task_screen.dart';
 import '../features/tasks/screens/offer_accepted_success_screen.dart';
 import '../features/payments/screens/payment_completion_screen.dart';
+import '../features/payments/screens/payment_authorization_screen.dart';
+import '../features/payments/screens/payment_success_screen.dart';
 import '../features/notifications/screens/notifications_screen.dart';
 import '../core/services/analytics_service.dart';
 import '../core/widgets/responsive_layout.dart';
@@ -250,6 +252,30 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             path: '/onboarding',
             name: 'onboarding',
             builder: (context, state) => const OnboardingScreen(),
+          ),
+          GoRoute(
+            path: '/payment/authorize',
+            name: 'payment-authorize',
+            builder: (context, state) {
+              final extra = (state.extra as Map?) ?? {};
+              return PaymentAuthorizationScreen(
+                paymentId: extra['paymentId'] as String,
+                clientSecret: extra['clientSecret'] as String,
+                amount: (extra['amount'] as num).toDouble(),
+                taskTitle: extra['taskTitle'] as String,
+              );
+            },
+          ),
+          GoRoute(
+            path: '/payment/success',
+            name: 'payment-success',
+            builder: (context, state) {
+              final extra = (state.extra as Map?) ?? {};
+              return PaymentSuccessScreen(
+                amount: (extra['amount'] as num).toDouble(),
+                taskTitle: extra['taskTitle'] as String,
+              );
+            },
           ),
           GoRoute(
             path: '/payment/:id',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,6 +430,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_stripe:
+    dependency: "direct main"
+    description:
+      name: flutter_stripe
+      sha256: a474b283f4b07e8973687514bf48762e618073b0d6b7acc45cea9a60466d4f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -460,18 +468,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "2d399f823b8849663744d2a9ddcce01c49268fb4170d0442a655bf6a2f47be22"
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "2.4.4"
   frontend_server_client:
     dependency: transitive
     description:
@@ -1044,10 +1052,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
+      sha256: "837a6dc33f490706c7f4632c516bcd10804ee4d9ccc8046124ca56388715fdf3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.10"
+    version: "0.5.9"
   riverpod_annotation:
     dependency: "direct main"
     description:
@@ -1060,10 +1068,10 @@ packages:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
+      sha256: "120d3310f687f43e7011bb213b90a436f1bbc300f0e4b251a72c39bccb017a4f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.5"
+    version: "2.6.4"
   rxdart:
     dependency: transitive
     description:
@@ -1285,6 +1293,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  stripe_android:
+    dependency: transitive
+    description:
+      name: stripe_android
+      sha256: a666352e0c20753ecd8feebb5944882bf597167be4f020641266515a495bd55f
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
+  stripe_ios:
+    dependency: transitive
+    description:
+      name: stripe_ios
+      sha256: "0f7afed3ac61e544e7525da9b692b23d93e762d56f6c9aa7f77fc6d9a686a65d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
+  stripe_platform_interface:
+    dependency: transitive
+    description:
+      name: stripe_platform_interface
+      sha256: "23c10f3875da07f85a6196fcb676e64c767ad2d04ec73ba4e941ac797a4ee4d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
   supabase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   geocoding: ^4.0.0
   http: ^1.2.1
   google_fonts: ^6.2.1
-  freezed_annotation: ^3.0.0
+  freezed_annotation: ^2.4.1
   json_annotation: ^4.9.0
   uuid: ^4.3.3
   smooth_page_indicator: ^1.2.1
@@ -45,7 +45,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   riverpod_generator: ^2.3.9
   build_runner: ^2.4.8
-  freezed: ^3.0.6
+  freezed: ^2.5.8
   json_serializable: ^6.7.1
 
 flutter:


### PR DESCRIPTION
- Add mock payment mode toggle via ApiConstants.mockPayments (default true for dev)
- PaymentController: short-circuit Stripe + DB in mock mode, return init data
- PaymentAuthorizationScreen: bypass Stripe UI in mock, call authorization and navigate to success
- Add developer-only "Complete (Mock)" action in Task Details when status is pending_payment
- Router: place /payment/authorize and /payment/success before /payment/:id to avoid shadowing

UI/Task logic:
- Remove obsolete 'assigned' status usage; map statuses to DB enums
- Ensure Start Task only for assigned tasker when status is pending
- Humanize application status labels
- Map pending_approval & pending_payment under Upcoming tasks filter
- Fix duplicate "Submit for Review" button in Task Details
- Update status badges/colors including pending_payment

Data layer:
- ApplicationRepository: default new application status to pending; add getUserApplications
- Remove unused acceptOffer path from ApplicationController

Build:
- Add flutter_stripe dependency; align freezed/freezed_annotation versions
- Update generated registrants and plugins